### PR TITLE
First implementation of chess pieces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,21 @@ if(MSVC)
 endif()
 
 set(CHESS_SRCS
-    main.cpp)
+    bishop.hpp
+    bishop.cpp
+    chess_piece.hpp
+    chess_piece.cpp
+    king.hpp
+    king.cpp
+    knight.hpp
+    knight.cpp
+    main.cpp
+    pawn.hpp
+    pawn.cpp
+    queen.hpp
+    queen.cpp
+    rook.hpp
+    rook.cpp)
 
 set(CHESS_TARGET chess)
 add_executable(${CHESS_TARGET} ${CHESS_SRCS})

--- a/bishop.cpp
+++ b/bishop.cpp
@@ -1,0 +1,17 @@
+#include "bishop.hpp"
+
+namespace chess
+{
+    bishop::bishop(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool bishop::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/bishop.hpp
+++ b/bishop.hpp
@@ -1,0 +1,21 @@
+#ifndef BISHOP_HPP
+#define BISHOP_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class bishop : public chess_piece
+    {
+    public:
+
+        bishop(color c, const position_type& pos);
+        virtual ~bishop() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+

--- a/chess_piece.cpp
+++ b/chess_piece.cpp
@@ -1,0 +1,26 @@
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    color chess_piece::get_color() const
+    {
+        return m_color;
+    }
+
+    const position_type& chess_piece::get_position() const
+    {
+        return m_position;
+    }
+
+    void chess_piece::move(const position_type& new_pos)
+    {
+        m_position = new_pos;
+    }
+
+    chess_piece::chess_piece(color c, const position_type& pos)
+        : m_color(c), m_position(pos)
+    {
+    }
+
+}
+

--- a/chess_piece.hpp
+++ b/chess_piece.hpp
@@ -1,0 +1,54 @@
+#ifndef CHESS_PIECE_HPP
+#define CHESS_PIECE_HPP
+
+#include <cstddef>
+#include <utility>
+
+namespace chess
+{
+    // We encode color with a simple char which can be 'w' or 'b'
+    using color = char;
+    using position_type = std::pair<char, std::size_t>;
+
+    class chess_piece
+    {
+    public:
+
+        // When the destructor is trivial (i.e. its implementation
+        // does not do anything), you can declare it as default
+        // and omit its implementation in the cpp. The same
+        // apply for copy and move constructor, and assign
+        // operators.
+        virtual ~chess_piece() = default;
+
+        // Entity semantic: we delete copy and move constructors
+        // and assign operators
+        chess_piece(const chess_piece&) = delete;
+        chess_piece& operator=(const chess_piece&) = delete;
+        chess_piece(chess_piece&&) = delete;
+        chess_piece& operator=(chess_piece&&) = delete;
+
+        color get_color() const;
+
+        const position_type& get_position() const;
+        void move(const position_type& new_pos);
+
+        // This is specific to the type of piece
+        virtual bool can_move(const position_type& new_pos) const = 0;
+
+    protected:
+
+        // Let's emphasize the entity semantic by defining
+        // the constructor as protected so it is clear we
+        // don't want this class to be instantiated by clients
+        chess_piece(color c, const position_type& pos);
+
+    private:
+
+        color m_color;
+        position_type m_position;
+    };
+}
+
+#endif
+

--- a/king.cpp
+++ b/king.cpp
@@ -1,0 +1,17 @@
+#include "king.hpp"
+
+namespace chess
+{
+    king::king(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool king::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/king.hpp
+++ b/king.hpp
@@ -1,0 +1,21 @@
+#ifndef KING_HPP
+#define KING_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class king : public chess_piece
+    {
+    public:
+
+        king(color c, const position_type& pos);
+        virtual ~king() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+

--- a/knight.cpp
+++ b/knight.cpp
@@ -1,0 +1,17 @@
+#include "knight.hpp"
+
+namespace chess
+{
+    knight::knight(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool knight::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/knight.hpp
+++ b/knight.hpp
@@ -1,0 +1,21 @@
+#ifndef KNIGHT_HPP
+#define KNIGHT_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class knight : public chess_piece
+    {
+    public:
+
+        knight(color c, const position_type& pos);
+        virtual ~knight() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+

--- a/pawn.cpp
+++ b/pawn.cpp
@@ -1,0 +1,17 @@
+#include "pawn.hpp"
+
+namespace chess
+{
+    pawn::pawn(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool pawn::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/pawn.hpp
+++ b/pawn.hpp
@@ -1,0 +1,21 @@
+#ifndef PAWN_HPP
+#define PAWN_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class pawn : public chess_piece
+    {
+    public:
+
+        pawn(color c, const position_type& pos);
+        virtual ~pawn() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+

--- a/queen.cpp
+++ b/queen.cpp
@@ -1,0 +1,17 @@
+#include "queen.hpp"
+
+namespace chess
+{
+    queen::queen(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool queen::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/queen.hpp
+++ b/queen.hpp
@@ -1,0 +1,21 @@
+#ifndef QUEEN_HPP
+#define QUEEN_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class queen : public chess_piece
+    {
+    public:
+
+        queen(color c, const position_type& pos);
+        virtual ~queen() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+

--- a/rook.cpp
+++ b/rook.cpp
@@ -1,0 +1,17 @@
+#include "rook.hpp"
+
+namespace chess
+{
+    rook::rook(color c, const position_type& pos)
+        : chess_piece(c, pos)
+    {
+    }
+
+    bool rook::can_move(const position_type& new_pos) const
+    {
+        // Let's return false for now, we'll implement
+        // it later
+        return false;
+    }
+}
+

--- a/rook.hpp
+++ b/rook.hpp
@@ -1,0 +1,21 @@
+#ifndef ROOK_HPP
+#define ROOK_HPP
+
+#include "chess_piece.hpp"
+
+namespace chess
+{
+    
+    class rook : public chess_piece
+    {
+    public:
+
+        rook(color c, const position_type& pos);
+        virtual ~rook() = default;
+        
+        bool can_move(const position_type& new_pos) const override;
+    };
+}
+
+#endif
+


### PR DESCRIPTION
A chess piece has a color and a position. It provides a simple API to read them and to set the position. It also provides a method checking if a move is valid. Everything but this latter method is common to all kinds of pieces.

We need to store the pieces in a container that accepts objects of the same type, and the `can_move` method is specific to the kind of a piece: we definitely need a hierarchy of classes, let's call the base class `chess_piece`. The `can_move` method should be virtual, other methods can be implemented in the base class.

We don't implement `can_move` for now, let's just push the skeleton of the classes.