### PR TITLE
Implemented pawn::can_move

### DIFF
--- a/chess_board.cpp
+++ b/chess_board.cpp
@@ -109,7 +109,7 @@ namespace chess
         }
         piece(to) = pce;
         piece(from) = nullptr;
-
+        pce-> notify_move();
     }
 
     void chess_board::print(std::ostream& out) const

--- a/chess_piece.cpp
+++ b/chess_piece.cpp
@@ -22,6 +22,11 @@ namespace chess
         m_position = new_pos;
     }
 
+    // Default implementation does nothing
+    void chess_piece::notify_move()
+    {
+    }
+
     chess_piece::chess_piece(color c, const position_type& pos)
         : m_color(c), m_position(pos)
     {

--- a/chess_piece.hpp
+++ b/chess_piece.hpp
@@ -55,6 +55,13 @@ namespace chess
                               const has_piece_callback& cb) const = 0;
         virtual void print(std::ostream& out) const = 0;
 
+        // Some implementation of can_move depends on whether the
+        // piece has already moved or not (typically the pawn).
+        // Therefore, we need a way to tell the piece that it has moved.
+        // However, most of the pieces don't need this information, so
+        // we provide a default implementation that does nothing.
+        virtual void notify_move();
+
     protected:
 
         // Let's emphasize the entity semantic by defining

--- a/main.cpp
+++ b/main.cpp
@@ -78,13 +78,22 @@ int main(int /*argc*/, char** /*argv*/)
     chess::chess_board board;
     board.print(std::cout);
     std::string input;
-    std::cout << "Enter your move: ro,co - rd,cd" << std::endl;
+    std::cout << "Enter your move: co,ro - cd,rd" << std::endl;
     std::getline(std::cin, input);
     chess::move_type pos;
     try
     {
         chess::get_move(input, pos);
-        std::cout << "Legal move: " << board.can_move(pos.first, pos.second) << std::endl;
+        bool legal_move = board.can_move(pos.first, pos.second);
+        if (legal_move)
+        {
+            board.move(pos.first, pos.second);
+            board.print(std::cout);
+        }
+        else
+        {
+            std::cout << "illegal move" << std::endl;
+        }
     }
     catch(std::exception& e)
     {

--- a/pawn.cpp
+++ b/pawn.cpp
@@ -4,15 +4,37 @@ namespace chess
 {
     pawn::pawn(color c, const position_type& pos)
         : chess_piece(c, pos)
+        , m_has_moved(false)
     {
     }
 
     bool pawn::can_move(const position_type& new_pos,
                         const has_piece_callback& cb) const
     {
-        // Let's return false for now, we'll implement
-        // it later
-        return false;
+        const position_type& current_pos = get_position();
+        bool valid = false;
+        bool same_column = new_pos.first == current_pos.first;
+        bool adv_1 = same_column && new_pos.second == current_pos.second + 1;
+        bool adv_2 = same_column && new_pos.second == current_pos.second + 2;
+        bool diag = (new_pos.first == current_pos.first + 1 || new_pos.first + 1 == current_pos.first)
+            && (new_pos.second == current_pos.second + 1u);
+        
+        opp_color = get_opposite_color();
+        if (diag)
+        {
+            valid = cb(new_pos, opp_color);
+        }
+        else if(adv_1)
+        {
+            valid = !cb(new_pos, opp_color);
+        }
+        else if(adv_2)
+        {
+            valid = !m_has_moved;
+            valid &= !cb(position_type(current_pos.first, current_pos.second + 1), opp_color);
+            valid &= !cb(new_pos, opp_color);
+        }
+        return valid;
     }
 
     void pawn::print(std::ostream& out) const

--- a/pawn.cpp
+++ b/pawn.cpp
@@ -19,7 +19,7 @@ namespace chess
         bool diag = (new_pos.first == current_pos.first + 1 || new_pos.first + 1 == current_pos.first)
             && (new_pos.second == current_pos.second + 1u);
         
-        opp_color = get_opposite_color();
+        color opp_color = get_opposite_color();
         if (diag)
         {
             valid = cb(new_pos, opp_color);
@@ -40,6 +40,11 @@ namespace chess
     void pawn::print(std::ostream& out) const
     {
         out << "P" << get_color();
+    }
+
+    void pawn::notify_move()
+    {
+        m_has_moved = true;
     }
 }
 

--- a/pawn.hpp
+++ b/pawn.hpp
@@ -16,6 +16,12 @@ namespace chess
         bool can_move(const position_type& new_pos,
                       const has_piece_callback& cb) const override;
         void print(std::ostream& out) const override;
+
+    private:
+
+        // The check in can_move depends on whether it's the first move
+        // of the pawn, so we need an additional data member.
+        bool m_has_moved;
     };
 }
 

--- a/pawn.hpp
+++ b/pawn.hpp
@@ -16,6 +16,7 @@ namespace chess
         bool can_move(const position_type& new_pos,
                       const has_piece_callback& cb) const override;
         void print(std::ostream& out) const override;
+        void notify_move() override;
 
     private:
 


### PR DESCRIPTION
The implementation of `pawn::can_move` leads to changes in the API of the `chess_piece` class.